### PR TITLE
Button refactor

### DIFF
--- a/include/modules/button.h
+++ b/include/modules/button.h
@@ -12,6 +12,8 @@
 namespace button {
 	void init();
 	void loop();
+	bool isPressed();
+	// For temporary backwards compatibility:
 	bool pushed();
 }
 


### PR DESCRIPTION
The motivation here is to separate the checking of state ("is the button pressed") from the code that alters internal state of the button. So we could, for example, more easily check if the button is being pressed and held vs. pressed and released quickly.