### PR TITLE
fix: add fiatPrecission to configs

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -20,6 +20,7 @@ namespace util {
 	std::string floatVectorToStringList(const std::vector<float> floatVector, const char &delimiter = ',');
 	std::string floatToString(const float &number);
 	std::string doubleToString(const double &number);
+	std::string shortToString(const short &number);
 	std::string unsignedIntToString(const unsigned int &number);
 	std::string byteToString(const byte &byteIn);
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -49,6 +49,9 @@ namespace {
 			t_values.coinValues = util::stringListToFloatVector(value);
 		} else if (key == "billValues") {
 			t_values.billValues = util::stringListToFloatVector(value);
+		} else if (key == "fiatPrecision") {
+			// Convert string to short:
+			t_values.fiatPrecision = (char)( *value.c_str() - '0' );
 		} else {
 			return false;
 		}
@@ -74,6 +77,8 @@ namespace {
 			return util::floatVectorToStringList(t_values.coinValues);
 		} else if (key == "billValues") {
 			return util::floatVectorToStringList(t_values.billValues);
+		} else if (key == "fiatPrecision") {
+			return util::shortToString(t_values.fiatPrecision);
 		}
 		return "";
 	}

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -71,6 +71,12 @@ namespace util {
 		return ss.str();
 	}
 
+	std::string shortToString(const short &number) {
+		std::ostringstream ss;
+		ss << number;
+		return ss.str();
+	}
+
 	std::string unsignedIntToString(const unsigned int &number) {
 		std::ostringstream ss;
 		ss << +number;


### PR DESCRIPTION
Adding attribute `fiatPrecission` to `setConfigValue` and `getConfigValue`.

Closes https://github.com/samotari/bleskomat-device/issues/76