### PR TITLE
Add install platform to make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ PORT ?= 443
 DEVICE ?= /dev/ttyUSB0
 BAUDRATE ?= 115200
 SCRIPTS=./scripts
+PLATFORM=espressif32
 
 ## Targets
 #
@@ -37,6 +38,7 @@ fetchCACert
 
 install:
 	platformio lib install
+	platformio platform install ${PLATFORM}
 
 compile:
 	platformio run


### PR DESCRIPTION
When installing fresh platformio cli was missing the platform `espressif32` so I guess it's better to add to installation.