### PR TITLE
add default description like "Bleskomat: 100 CZK" or "Bleskomat: 20 EUR"

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -48,11 +48,11 @@ namespace util {
 		std::string amount = floatToStringWithPrecision(t_amount, config::getUnsignedInt("fiatPrecision"));
 		params.minWithdrawable = amount;
 		params.maxWithdrawable = amount;
-		params.defaultDescription = "";
 		for (auto const &it : customParams) {
 			params.custom[it.first] = it.second;
 		}
 		params.custom["f"] = config::getString("fiatCurrency");
+		params.defaultDescription = "Bleskomat: " + amount + " " + params.custom["f"];
 		return signer.create_url(params, nonce);
 	}
 


### PR DESCRIPTION
just an idea to have a simple identificator in the LN wallet so the customer knows this is the payment from Bleskomat. Tested only with CZK but I don't expect any troubles with other currencies because it uses the config::getString("fiatCurrency")

add default description e.g.
"Bleskomat: 100 CZK" or "Bleskomat: 20 EUR"